### PR TITLE
fix: correct typo in function name export_settigns → export_settings

### DIFF
--- a/src/plf/lab.py
+++ b/src/plf/lab.py
@@ -15,7 +15,7 @@ from .utils import Db
 
 __all__ = ["lab_setup", "create_project", "get_logs", 'create_clone', 'init_clone']
  
-def export_settigns():
+def export_settings():
     settings = get_shared_data()
     # Change project_path to data_path parent
     pth = os.path.join(Path(settings['data_path']).parent, settings["project_name"] + ".json")


### PR DESCRIPTION
## Summary

Fixes a typo in `src/plf/lab.py` where the function `export_settigns` was misspelled.

### Changes

- `src/plf/lab.py`: Changed `def export_settigns()` → `def export_settings()`

### Motivation

The misspelled function name breaks any code trying to call `export_settings()`.

Closes #12