### PR TITLE
Fix typo error in lab.py

### DIFF
--- a/src/plf/lab.py
+++ b/src/plf/lab.py
@@ -14,8 +14,9 @@ from .context import set_shared_data, get_caller, register_libs_path, get_shared
 from .utils import Db
 
 __all__ = ["lab_setup", "create_project", "get_logs", 'create_clone', 'init_clone']
- 
-def export_settigns():
+
+# Function changed to its correct name
+def export_settings():
     settings = get_shared_data()
     # Change project_path to data_path parent
     pth = os.path.join(Path(settings['data_path']).parent, settings["project_name"] + ".json")


### PR DESCRIPTION
Closes Issue #12 
Fixed the typo error and corrected the name of the function to "def export_settings():".
The change is done to prevent the confusion of readers who might read the code and thereby improve the clarity.