### PR TITLE
Add plf CLI interface (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ The `plf.experiment` module provides powerful tools for managing your PPL databa
 
 ---
 
+## 🖥 CLI Usage (`plf`)
+
+After installing PyLabFlow, the `plf` command is available in your terminal.
+
+```bash
+plf --help                             # list all commands
+plf status                             # show PPL status table
+plf list                               # list active PPL IDs
+plf run <pplid>                        # run a pipeline
+plf archive <pplid>                    # archive a pipeline
+plf delete <pplid>                     # delete from archive
+plf stop                               # gracefully stop running pipeline(s)
+plf export <pplid> --format yaml       # export config (yaml or json)
+plf init --config settings.json        # initialize lab from config file
+```
+
+The CLI auto-detects your lab by walking up from the current directory looking for `settings.json`, similar to how `git` finds `.git/`. You can also pass `--settings <path>` explicitly.
+
+---
+
 ## 📜 License
 
 This project is licensed under the **Apache License 2.0**.  © 2025 BBEK Anand

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,14 @@ setup(
     packages=find_packages(where='src'),
     include_package_data=True,
     install_requires=[
-        'pandas'
+        'pandas',
+        'click'
     ],
+    entry_points={
+        'console_scripts': [
+            'plf = plf.cli:main',
+        ],
+    },
     author='BBEK-Anand',
     author_email='',
     description='PyLabFlow is a lightweight framework that simplifies experiment management, reducing setup time with reusable components for training, logging, and checkpointing. It streamlines workflows, making it ideal for fast and efficient experimentation.',

--- a/src/plf/cli.py
+++ b/src/plf/cli.py
@@ -1,0 +1,172 @@
+"""
+plf - command line interface for PyLabFlow.
+
+Lets users manage experiment pipelines (PPLs) from the terminal,
+without writing Python scripts or opening a Jupyter notebook.
+"""
+
+import json
+import os
+import sys
+
+import click
+
+from plf.lab import create_project, lab_setup
+from plf.experiment import (
+    PipeLine,
+    archive_ppl,
+    delete_ppl,
+    get_ppl_status,
+    get_ppls,
+    get_runnings,
+)
+
+
+def _load_lab(settings):
+    """
+    Load the active lab. If `settings` is given, use that file.
+    Otherwise walk up from cwd looking for a settings.json (like git finds .git/).
+    """
+    if settings:
+        lab_setup(settings)
+        return
+
+    path = os.getcwd()
+    while True:
+        candidate = os.path.join(path, "settings.json")
+        if os.path.exists(candidate):
+            lab_setup(candidate)
+            return
+        parent = os.path.dirname(path)
+        if parent == path:
+            break
+        path = parent
+
+    click.echo("Error: No settings.json found in current or parent directories.", err=True)
+    click.echo("Tip: run `plf init --config <settings.json>` first, or use --settings.", err=True)
+    sys.exit(1)
+
+
+@click.group()
+@click.option("--settings", default=None, help="Path to settings.json (overrides auto-detect).")
+@click.pass_context
+def main(ctx, settings):
+    """plf - PyLabFlow CLI for managing experiment pipelines."""
+    ctx.ensure_object(dict)
+    ctx.obj["settings"] = settings
+
+
+@main.command()
+@click.pass_context
+def status(ctx):
+    """Show status of all PPLs as a table."""
+    _load_lab(ctx.obj["settings"])
+    df = get_ppl_status()
+    if df is None or df.empty:
+        click.echo("No pipelines found.")
+        return
+    if "pplid" not in df.columns:
+        df = df.reset_index().rename(columns={"index": "pplid"})
+    click.echo(df.to_string(index=False))
+
+
+@main.command(name="list")
+@click.pass_context
+def list_ppls(ctx):
+    """List all active PPL IDs."""
+    _load_lab(ctx.obj["settings"])
+    ppls = get_ppls()
+    if not ppls:
+        click.echo("No active pipelines.")
+        return
+    for ppl in ppls:
+        click.echo(ppl)
+
+
+@main.command()
+@click.argument("pplid")
+@click.pass_context
+def run(ctx, pplid):
+    """Run a specific pipeline by PPLID."""
+    _load_lab(ctx.obj["settings"])
+    P = PipeLine()
+    P.load(pplid)
+    P.prepare()
+    P.run()
+    click.echo(f"Finished: {pplid}")
+
+
+@main.command()
+@click.argument("pplid")
+@click.pass_context
+def archive(ctx, pplid):
+    """Archive a pipeline."""
+    _load_lab(ctx.obj["settings"])
+    archive_ppl([pplid])
+    click.echo(f"Archived: {pplid}")
+
+
+@main.command()
+@click.argument("pplid")
+@click.pass_context
+def delete(ctx, pplid):
+    """Delete a pipeline from the archive."""
+    _load_lab(ctx.obj["settings"])
+    delete_ppl([pplid])
+    click.echo(f"Deleted: {pplid}")
+
+
+@main.command()
+@click.pass_context
+def stop(ctx):
+    """Gracefully stop any currently running pipeline(s)."""
+    _load_lab(ctx.obj["settings"])
+    df = get_runnings()
+    if df is None or df.empty:
+        click.echo("No pipeline is currently running.")
+        return
+    for pplid in df["pplid"].unique():
+        P = PipeLine()
+        P.load(pplid)
+        P.stop_running()
+
+
+@main.command()
+@click.argument("pplid")
+@click.option("--format", "fmt", type=click.Choice(["yaml", "json"]), default="json", show_default=True)
+@click.option("--out", default=".", show_default=True, help="Output directory.")
+@click.pass_context
+def export(ctx, pplid, fmt, out):
+    """Export a pipeline config to YAML or JSON."""
+    _load_lab(ctx.obj["settings"])
+    P = PipeLine()
+    P.load(pplid)
+    config = P.cnfg
+    os.makedirs(out, exist_ok=True)
+    outfile = os.path.join(out, f"{pplid}.{fmt}")
+    if fmt == "json":
+        with open(outfile, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+    else:  # yaml
+        try:
+            import yaml
+        except ImportError:
+            click.echo("PyYAML is not installed. Run: pip install pyyaml", err=True)
+            sys.exit(1)
+        with open(outfile, "w", encoding="utf-8") as f:
+            yaml.dump(config, f)
+    click.echo(f"Exported to {outfile}")
+
+
+@main.command(name="init")
+@click.option("--config", required=True, help="Path to a settings JSON file.")
+def init(config):
+    """Set up a lab environment from a settings file."""
+    with open(config, encoding="utf-8") as f:
+        settings = json.load(f)
+    settings_path = create_project(settings)
+    click.echo(f"Lab initialized. Settings at: {settings_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,135 @@
+import pandas as pd
+from click.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from plf.cli import main
+
+runner = CliRunner()
+
+
+def invoke(args, settings="fake_settings.json"):
+    return runner.invoke(main, ["--settings", settings] + args)
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.get_ppls", return_value=["ppl_001", "ppl_002"])
+def test_list(mock_ppls, mock_setup):
+    result = invoke(["list"])
+    assert result.exit_code == 0
+    assert "ppl_001" in result.output
+    assert "ppl_002" in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.get_ppls", return_value=[])
+def test_list_empty(mock_ppls, mock_setup):
+    result = invoke(["list"])
+    assert result.exit_code == 0
+    assert "No active pipelines." in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.get_ppl_status")
+def test_status(mock_status, mock_setup):
+    mock_status.return_value = pd.DataFrame({
+        "pplid": ["ppl_001"],
+        "status": ["frozen"],
+        "last_run": ["2025-11-02 14:30:00"],
+        "result": [0.923],
+    })
+    result = invoke(["status"])
+    assert result.exit_code == 0
+    assert "ppl_001" in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.get_ppl_status", return_value=pd.DataFrame())
+def test_status_empty(mock_status, mock_setup):
+    result = invoke(["status"])
+    assert result.exit_code == 0
+    assert "No pipelines found." in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.PipeLine")
+def test_run(mock_pipeline_cls, mock_setup):
+    mock_instance = MagicMock()
+    mock_pipeline_cls.return_value = mock_instance
+    result = invoke(["run", "ppl_001"])
+    assert result.exit_code == 0
+    mock_instance.load.assert_called_once_with("ppl_001")
+    mock_instance.prepare.assert_called_once()
+    mock_instance.run.assert_called_once()
+    assert "Finished: ppl_001" in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.archive_ppl")
+def test_archive(mock_archive, mock_setup):
+    result = invoke(["archive", "ppl_001"])
+    assert result.exit_code == 0
+    mock_archive.assert_called_once_with(["ppl_001"])
+    assert "Archived: ppl_001" in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.delete_ppl")
+def test_delete(mock_delete, mock_setup):
+    result = invoke(["delete", "ppl_001"])
+    assert result.exit_code == 0
+    mock_delete.assert_called_once_with(["ppl_001"])
+    assert "Deleted: ppl_001" in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.get_runnings", return_value=pd.DataFrame())
+def test_stop_idle(mock_runnings, mock_setup):
+    result = invoke(["stop"])
+    assert result.exit_code == 0
+    assert "No pipeline is currently running." in result.output
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.PipeLine")
+@patch("plf.cli.get_runnings")
+def test_stop_running(mock_runnings, mock_pipeline_cls, mock_setup):
+    mock_runnings.return_value = pd.DataFrame({"pplid": ["ppl_001"]})
+    mock_instance = MagicMock()
+    mock_pipeline_cls.return_value = mock_instance
+    result = invoke(["stop"])
+    assert result.exit_code == 0
+    mock_instance.load.assert_called_once_with("ppl_001")
+    mock_instance.stop_running.assert_called_once()
+
+
+@patch("plf.cli.lab_setup")
+@patch("plf.cli.PipeLine")
+def test_export_json(mock_pipeline_cls, mock_setup, tmp_path):
+    mock_instance = MagicMock()
+    mock_instance.cnfg = {"pplid": "ppl_001", "args": {}}
+    mock_pipeline_cls.return_value = mock_instance
+
+    out_dir = tmp_path / "out"
+    result = invoke(["export", "ppl_001", "--out", str(out_dir)])
+
+    assert result.exit_code == 0
+    out_file = out_dir / "ppl_001.json"
+    assert out_file.exists()
+
+
+@patch("plf.cli.create_project", return_value="/fake/path/settings.json")
+def test_init(mock_create_project, tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"project_name": "test", "project_dir": ".", "component_dir": "."}')
+
+    result = runner.invoke(main, ["init", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    mock_create_project.assert_called_once()
+    assert "Lab initialized" in result.output
+
+
+def test_help():
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "plf" in result.output


### PR DESCRIPTION
## Summary
- Adds a `plf` console-script CLI (`status`, `list`, `run`, `archive`, `delete`, `stop`, `export`, `init`) as a thin shell over `plf.experiment` / `plf.lab`.
- Auto-detects the active lab by walking up from cwd for `settings.json`, or accepts `--settings <path>` to override.
- Registers the `plf = plf.cli:main` entry point and adds `click` to `install_requires`.
- Documents CLI usage in the README.

## Test plan
- [x] `pip install -e .` then `plf --help` and per-command `--help`
- [x] `pytest tests/test_cli.py` (12 passing)
- [x] End-to-end smoke test against a real lab/pipeline: list, status, run, export (json/yaml), stop, archive, delete, init

Fixes #20
